### PR TITLE
ISO 4217 Currency Code Support

### DIFF
--- a/src/Portalum.Zvt/Models/CurrencyCodeIso4217.cs
+++ b/src/Portalum.Zvt/Models/CurrencyCodeIso4217.cs
@@ -1,0 +1,996 @@
+﻿namespace Portalum.Zvt.Models;
+
+/// <summary>
+/// Currency codes in 120 4217 - sourced from wikipedia
+/// </summary>
+public enum CurrencyCodeIso4217
+{
+    /// <summary>
+    /// Undefined
+    /// </summary>
+    Undefined = 000,
+
+    /// <summary>
+    /// Albanian Lek
+    /// ALL is used in Albania
+    /// </summary>
+    ALL = 008,
+
+    /// <summary>
+    /// Algerian Dinar
+    /// DZD is used in Algeria
+    /// </summary>
+    DZD = 012,
+
+    /// <summary>
+    /// Argentine Peso
+    /// ARS is used in Argentina
+    /// </summary>
+    ARS = 032,
+
+    /// <summary>
+    /// Australian Dollar
+    /// AUD is used in Australia
+    /// </summary>
+    AUD = 036,
+
+    /// <summary>
+    /// Bahamian Dollar
+    /// BSD is used in The Bahamas
+    /// </summary>
+    BSD = 044,
+
+    /// <summary>
+    /// Bahraini Dinar
+    /// BHD is used in Bahrain
+    /// </summary>
+    BHD = 048,
+
+    /// <summary>
+    /// Bangladeshi Taka
+    /// BDT is used in Bangladesh
+    /// </summary>
+    BDT = 050,
+
+    /// <summary>
+    /// Armenian Dram
+    /// AMD is used in Armenia
+    /// </summary>
+    AMD = 051,
+
+    /// <summary>
+    /// Barbadian Dollar
+    /// BBD is used in Barbados
+    /// </summary>
+    BBD = 052,
+
+    /// <summary>
+    /// Bermudian Dollar
+    /// BMD is used in Bermuda
+    /// </summary>
+    BMD = 060,
+
+    /// <summary>
+    /// Bhutanese Ngultrum
+    /// BTN is used in Bhutan
+    /// </summary>
+    BTN = 064,
+
+    /// <summary>
+    /// Bolivian Boliviano
+    /// BOB is used in Bolivia
+    /// </summary>
+    BOB = 068,
+
+    /// <summary>
+    /// Botswana Pula
+    /// BWP is used in Botswana
+    /// </summary>
+    BWP = 072,
+
+    /// <summary>
+    /// Belize Dollar
+    /// BZD is used in Belize
+    /// </summary>
+    BZD = 084,
+
+    /// <summary>
+    /// Solomon Islands Dollar
+    /// SBD is used in Solomon Islands
+    /// </summary>
+    SBD = 090,
+
+    /// <summary>
+    /// Brunei Dollar
+    /// BND is used in Brunei
+    /// </summary>
+    BND = 096,
+
+    /// <summary>
+    /// Burmese Kyat
+    /// MMK is used in Myanmar (Burma)
+    /// </summary>
+    MMK = 104,
+
+    /// <summary>
+    /// Burundian Franc
+    /// BIF is used in Burundi
+    /// </summary>
+    BIF = 108,
+
+    /// <summary>
+    /// Cambodian Riel
+    /// KHR is used in Cambodia
+    /// </summary>
+    KHR = 116,
+
+    /// <summary>
+    /// Canadian Dollar
+    /// CAD is used in Canada
+    /// </summary>
+    CAD = 124,
+
+    /// <summary>
+    /// Cape Verdean Escudo
+    /// CVE is used in Cape Verde
+    /// </summary>
+    CVE = 132,
+
+    /// <summary>
+    /// Cayman Islands Dollar
+    /// KYD is used in the Cayman Islands
+    /// </summary>
+    KYD = 136,
+
+    /// <summary>
+    /// Sri Lankan Rupee
+    /// LKR is used in Sri Lanka
+    /// </summary>
+    LKR = 144,
+
+    /// <summary>
+    /// Chilean Peso
+    /// CLP is used in Chile
+    /// </summary>
+    CLP = 152,
+
+    /// <summary>
+    /// Chinese Yuan
+    /// CNY is used in China
+    /// </summary>
+    CNY = 156,
+
+    /// <summary>
+    /// Colombian Peso
+    /// COP is used in Colombia
+    /// </summary>
+    COP = 170,
+
+    /// <summary>
+    /// Comorian Franc
+    /// KMF is used in Comoros
+    /// </summary>
+    KMF = 174,
+
+    /// <summary>
+    /// Costa Rican Colón
+    /// CRC is used in Costa Rica
+    /// </summary>
+    CRC = 188,
+
+    /// <summary>
+    /// Cuban Peso
+    /// CUP is used in Cuba
+    /// </summary>
+    CUP = 192,
+
+    /// <summary>
+    /// Czech Koruna
+    /// CZK is used in the Czech Republic
+    /// </summary>
+    CZK = 203,
+
+    /// <summary>
+    /// Danish Krone
+    /// DKK is used in Denmark
+    /// </summary>
+    DKK = 208,
+
+    /// <summary>
+    /// Dominican Peso
+    /// DOP is used in the Dominican Republic
+    /// </summary>
+    DOP = 214,
+
+    /// <summary>
+    /// Salvadoran Colón
+    /// SVC is used in El Salvador
+    /// </summary>
+    SVC = 222,
+
+    /// <summary>
+    /// Ethiopian Birr
+    /// ETB is used in Ethiopia
+    /// </summary>
+    ETB = 230,
+
+    /// <summary>
+    /// Eritrean Nakfa
+    /// ERN is used in Eritrea
+    /// </summary>
+    ERN = 232,
+
+    /// <summary>
+    /// Falkland Islands Pound
+    /// FKP is used in the Falkland Islands
+    /// </summary>
+    FKP = 238,
+
+    /// <summary>
+    /// Fijian Dollar
+    /// FJD is used in Fiji
+    /// </summary>
+    FJD = 242,
+
+    /// <summary>
+    /// Djiboutian Franc
+    /// DJF is used in Djibouti
+    /// </summary>
+    DJF = 262,
+
+    /// <summary>
+    /// Gambian Dalasi
+    /// GMD is used in The Gambia
+    /// </summary>
+    GMD = 270,
+
+    /// <summary>
+    /// Gibraltar Pound
+    /// GIP is used in Gibraltar
+    /// </summary>
+    GIP = 292,
+
+    /// <summary>
+    /// Guatemalan Quetzal
+    /// GTQ is used in Guatemala
+    /// </summary>
+    GTQ = 320,
+
+    /// <summary>
+    /// Guinean Franc
+    /// GNF is used in Guinea
+    /// </summary>
+    GNF = 324,
+
+    /// <summary>
+    /// Guyanese Dollar
+    /// GYD is used in Guyana
+    /// </summary>
+    GYD = 328,
+
+    /// <summary>
+    /// Haitian Gourde
+    /// HTG is used in Haiti
+    /// </summary>
+    HTG = 332,
+
+    /// <summary>
+    /// Honduran Lempira
+    /// HNL is used in Honduras
+    /// </summary>
+    HNL = 340,
+
+    /// <summary>
+    /// Hong Kong Dollar
+    /// HKD is used in Hong Kong
+    /// </summary>
+    HKD = 344,
+
+    /// <summary>
+    /// Hungarian Forint
+    /// HUF is used in Hungary
+    /// </summary>
+    HUF = 348,
+
+    /// <summary>
+    /// Icelandic Króna
+    /// ISK is used in Iceland
+    /// </summary>
+    ISK = 352,
+
+    /// <summary>
+    /// Indian Rupee
+    /// INR is used in India
+    /// </summary>
+    INR = 356,
+
+    /// <summary>
+    /// Indonesian Rupiah
+    /// IDR is used in Indonesia
+    /// </summary>
+    IDR = 360,
+
+    /// <summary>
+    /// Iranian Rial
+    /// IRR is used in Iran
+    /// </summary>
+    IRR = 364,
+
+    /// <summary>
+    /// Iraqi Dinar
+    /// IQD is used in Iraq
+    /// </summary>
+    IQD = 368,
+
+    /// <summary>
+    /// Israeli New Shekel
+    /// ILS is used in Israel
+    /// </summary>
+    ILS = 376,
+
+    /// <summary>
+    /// Jamaican Dollar
+    /// JMD is used in Jamaica
+    /// </summary>
+    JMD = 388,
+
+    /// <summary>
+    /// Japanese Yen
+    /// JPY is used in Japan
+    /// </summary>
+    JPY = 392,
+
+    /// <summary>
+    /// Kazakhstani Tenge
+    /// KZT is used in Kazakhstan
+    /// </summary>
+    KZT = 398,
+
+    /// <summary>
+    /// Jordanian Dinar
+    /// JOD is used in Jordan
+    /// </summary>
+    JOD = 400,
+
+    /// <summary>
+    /// Kenyan Shilling
+    /// KES is used in Kenya
+    /// </summary>
+    KES = 404,
+
+    /// <summary>
+    /// North Korean Won
+    /// KPW is used in North Korea
+    /// </summary>
+    KPW = 408,
+
+    /// <summary>
+    /// South Korean Won
+    /// KRW is used in South Korea
+    /// </summary>
+    KRW = 410,
+
+    /// <summary>
+    /// Kuwaiti Dinar
+    /// KWD is used in Kuwait
+    /// </summary>
+    KWD = 414,
+
+    /// <summary>
+    /// Kyrgyzstani Som
+    /// KGS is used in Kyrgyzstan
+    /// </summary>
+    KGS = 417,
+
+    /// <summary>
+    /// Lao Kip
+    /// LAK is used in Laos
+    /// </summary>
+    LAK = 418,
+
+    /// <summary>
+    /// Lebanese Pound
+    /// LBP is used in Lebanon
+    /// </summary>
+    LBP = 422,
+
+    /// <summary>
+    /// Lesotho Loti
+    /// LSL is used in Lesotho
+    /// </summary>
+    LSL = 426,
+
+    /// <summary>
+    /// Liberian Dollar
+    /// LRD is used in Liberia
+    /// </summary>
+    LRD = 430,
+
+    /// <summary>
+    /// Libyan Dinar
+    /// LYD is used in Libya
+    /// </summary>
+    LYD = 434,
+
+    /// <summary>
+    /// Macanese Pataca
+    /// MOP is used in Macao
+    /// </summary>
+    MOP = 446,
+
+    /// <summary>
+    /// Malawian Kwacha
+    /// MWK is used in Malawi
+    /// </summary>
+    MWK = 454,
+
+    /// <summary>
+    /// Malaysian Ringgit
+    /// MYR is used in Malaysia
+    /// </summary>
+    MYR = 458,
+
+    /// <summary>
+    /// Maldivian Rufiyaa
+    /// MVR is used in Maldives
+    /// </summary>
+    MVR = 462,
+
+    /// <summary>
+    /// Mauritian Rupee
+    /// MUR is used in Mauritius
+    /// </summary>
+    MUR = 480,
+
+    /// <summary>
+    /// Mexican Peso
+    /// MXN is used in Mexico
+    /// </summary>
+    MXN = 484,
+
+    /// <summary>
+    /// Mongolian Tugrik
+    /// MNT is used in Mongolia
+    /// </summary>
+    MNT = 496,
+
+    /// <summary>
+    /// Moldovan Leu
+    /// MDL is used in Moldova
+    /// </summary>
+    MDL = 498,
+
+    /// <summary>
+    /// Moroccan Dirham
+    /// MAD is used in Morocco
+    /// </summary>
+    MAD = 504,
+
+    /// <summary>
+    /// Omani Rial
+    /// OMR is used in Oman
+    /// </summary>
+    OMR = 512,
+
+    /// <summary>
+    /// Namibian Dollar
+    /// NAD is used in Namibia
+    /// </summary>
+    NAD = 516,
+
+    /// <summary>
+    /// Nepalese Rupee
+    /// NPR is used in Nepal
+    /// </summary>
+    NPR = 524,
+
+    /// <summary>
+    /// Netherlands Antillean Guilder
+    /// ANG is used in Curaçao, Sint Maarten, Caribbean Netherlands
+    /// </summary>
+    ANG = 532,
+
+    /// <summary>
+    /// Aruban Florin
+    /// AWG is used in Aruba
+    /// </summary>
+    AWG = 533,
+
+    /// <summary>
+    /// Vanuatu Vatu
+    /// VUV is used in Vanuatu
+    /// </summary>
+    VUV = 548,
+
+    /// <summary>
+    /// New Zealand Dollar
+    /// NZD is used in New Zealand
+    /// </summary>
+    NZD = 554,
+
+    /// <summary>
+    /// Nicaraguan Córdoba
+    /// NIO is used in Nicaragua
+    /// </summary>
+    NIO = 558,
+
+    /// <summary>
+    /// Nigerian Naira
+    /// NGN is used in Nigeria
+    /// </summary>
+    NGN = 566,
+
+    /// <summary>
+    /// Norwegian Krone
+    /// NOK is used in Norway
+    /// </summary>
+    NOK = 578,
+
+    /// <summary>
+    /// Pakistani Rupee
+    /// PKR is used in Pakistan
+    /// </summary>
+    PKR = 586,
+
+    /// <summary>
+    /// Panamanian Balboa
+    /// PAB is used in Panama
+    /// </summary>
+    PAB = 590,
+
+    /// <summary>
+    /// Papua New Guinean Kina
+    /// PGK is used in Papua New Guinea
+    /// </summary>
+    PGK = 598,
+
+    /// <summary>
+    /// Paraguayan Guarani
+    /// PYG is used in Paraguay
+    /// </summary>
+    PYG = 600,
+
+    /// <summary>
+    /// Peruvian Sol
+    /// PEN is used in Peru
+    /// </summary>
+    PEN = 604,
+
+    /// <summary>
+    /// Philippine Peso
+    /// PHP is used in the Philippines
+    /// </summary>
+    PHP = 608,
+
+    /// <summary>
+    /// Qatari Riyal
+    /// QAR is used in Qatar
+    /// </summary>
+    QAR = 634,
+
+    /// <summary>
+    /// Russian Ruble
+    /// RUB is used in Russia
+    /// </summary>
+    RUB = 643,
+
+    /// <summary>
+    /// Rwandan Franc
+    /// RWF is used in Rwanda
+    /// </summary>
+    RWF = 646,
+
+    /// <summary>
+    /// Saint Helena Pound
+    /// SHP is used in Saint Helena
+    /// </summary>
+    SHP = 654,
+
+    /// <summary>
+    /// Saudi Riyal
+    /// SAR is used in Saudi Arabia
+    /// </summary>
+    SAR = 682,
+
+    /// <summary>
+    /// Seychellois Rupee
+    /// SCR is used in Seychelles
+    /// </summary>
+    SCR = 690,
+
+    /// <summary>
+    /// Sierra Leonean Leone
+    /// SLL is used in Sierra Leone
+    /// </summary>
+    SLE = 694,
+
+    /// <summary>
+    /// Singapore Dollar
+    /// SGD is used in Singapore
+    /// </summary>
+    SGD = 702,
+
+    /// <summary>
+    /// Vietnamese đồng
+    /// VND is used in Vietnam
+    /// </summary>
+    VND = 704,
+
+    /// <summary>
+    /// Somali Shilling
+    /// SOS is used in Somalia
+    /// </summary>
+    SOS = 706,
+
+    /// <summary>
+    /// South African Rand
+    /// ZAR is used in South Africa, Lesotho, Namibia, Eswatini
+    /// </summary>
+    ZAR = 710,
+
+    /// <summary>
+    /// South Sudanese Pound
+    /// SSP is used in South Sudan
+    /// </summary>
+    SSP = 728,
+
+    /// <summary>
+    /// Swazi Lilangeni
+    /// SZL is used in Eswatini
+    /// </summary>
+    SZL = 748,
+
+    /// <summary>
+    /// Swedish Krona
+    /// SEK is used in Sweden
+    /// </summary>
+    SEK = 752,
+
+    /// <summary>
+    /// Swiss Franc
+    /// CHF is used in Switzerland, Liechtenstein
+    /// </summary>
+    CHF = 756,
+
+    /// <summary>
+    /// Syrian Pound
+    /// SYP is used in Syria
+    /// </summary>
+    SYP = 760,
+
+    /// <summary>
+    /// Thai Baht
+    /// THB is used in Thailand
+    /// </summary>
+    THB = 764,
+
+    /// <summary>
+    /// Tongan Pa'anga
+    /// TOP is used in Tonga
+    /// </summary>
+    TOP = 776,
+
+    /// <summary>
+    /// Trinidad and Tobago Dollar
+    /// TTD is used in Trinidad and Tobago
+    /// </summary>
+    TTD = 780,
+
+    /// <summary>
+    /// United Arab Emirates Dirham
+    /// AED is used in the United Arab Emirates
+    /// </summary>
+    AED = 784,
+
+    /// <summary>
+    /// Tunisian Dinar
+    /// TND is used in Tunisia
+    /// </summary>
+    TND = 788,
+
+    /// <summary>
+    /// Ugandan Shilling
+    /// UGX is used in Uganda
+    /// </summary>
+    UGX = 800,
+
+    /// <summary>
+    /// Macedonian Denar
+    /// MKD is used in North Macedonia
+    /// </summary>
+    MKD = 807,
+
+    /// <summary>
+    /// Egyptian Pound
+    /// EGP is used in Egypt
+    /// </summary>
+    EGP = 818,
+
+    /// <summary>
+    /// British Pound Sterling
+    /// GBP is used in the United Kingdom, Crown dependencies, British Overseas Territories
+    /// </summary>
+    GBP = 826,
+
+    /// <summary>
+    /// Tanzanian Shilling
+    /// TZS is used in Tanzania
+    /// </summary>
+    TZS = 834,
+
+    /// <summary>
+    /// United States Dollar
+    /// USD is used in the United States, Ecuador, El Salvador, Marshall Islands, Micronesia, Palau, Panama, East Timor, Zimbabwe
+    /// </summary>
+    USD = 840,
+
+    /// <summary>
+    /// Uruguayan Peso
+    /// UYU is used in Uruguay
+    /// </summary>
+    UYU = 858,
+
+    /// <summary>
+    /// Uzbekistan Som
+    /// UZS is used in Uzbekistan
+    /// </summary>
+    UZS = 860,
+
+    /// <summary>
+    /// Samoan Tala
+    /// WST is used in Samoa
+    /// </summary>
+    WST = 882,
+
+    /// <summary>
+    /// Yemeni Rial
+    /// YER is used in Yemen
+    /// </summary>
+    YER = 886,
+
+    /// <summary>
+    /// New Taiwan Dollar
+    /// TWD is used in Taiwan
+    /// </summary>
+    TWD = 901,
+
+    /// <summary>
+    /// Uruguayan Peso (Indexed Units)
+    /// UYW is used in Uruguay
+    /// </summary>
+    UYW = 927,
+
+    /// <summary>
+    /// Venezuelan Bolívar
+    /// VES is used in Venezuela
+    /// </summary>
+    VES = 928,
+
+    /// <summary>
+    /// Mauritanian Ouguiya
+    /// MRU is used in Mauritania
+    /// </summary>
+    MRU = 929,
+
+    /// <summary>
+    /// São Tomé and Príncipe Dobra
+    /// STN is used in São Tomé and Príncipe
+    /// </summary>
+    STN = 930,
+
+    /// <summary>
+    /// Cuban Convertible Peso
+    /// CUC is used in Cuba
+    /// </summary>
+    CUC = 931,
+
+    /// <summary>
+    /// Zimbabwean Dollar
+    /// ZWL is used in Zimbabwe
+    /// </summary>
+    ZWL = 932,
+
+    /// <summary>
+    /// Belarusian Ruble
+    /// BYN is used in Belarus
+    /// </summary>
+    BYN = 933,
+
+    /// <summary>
+    /// Turkmenistan Manat
+    /// TMT is used in Turkmenistan
+    /// </summary>
+    TMT = 934,
+
+    /// <summary>
+    /// Ghanaian Cedi
+    /// GHS is used in Ghana
+    /// </summary>
+    GHS = 936,
+
+    /// <summary>
+    /// Sudanese Pound
+    /// SDG is used in Sudan
+    /// </summary>
+    SDG = 938,
+
+    /// <summary>
+    /// Uruguayan Peso (Uruguay Indexed Units)
+    /// UYI is used in Uruguay
+    /// </summary>
+    UYI = 940,
+
+    /// <summary>
+    /// Serbian Dinar
+    /// RSD is used in Serbia
+    /// </summary>
+    RSD = 941,
+
+    /// <summary>
+    /// Mozambican Metical
+    /// MZN is used in Mozambique
+    /// </summary>
+    MZN = 943,
+
+    /// <summary>
+    /// Azerbaijani Manat
+    /// AZN is used in Azerbaijan
+    /// </summary>
+    AZN = 944,
+
+    /// <summary>
+    /// Romanian Leu
+    /// RON is used in Romania
+    /// </summary>
+    RON = 946,
+
+    /// <summary>
+    /// Swiss Franc (WIR Euro)
+    /// CHE is used in Switzerland
+    /// </summary>
+    CHE = 947,
+
+    /// <summary>
+    /// Swiss Franc (WIR Franc)
+    /// CHW is used in Switzerland
+    /// </summary>
+    CHW = 948,
+
+    /// <summary>
+    /// Turkish Lira
+    /// TRY is used in Turkey
+    /// </summary>
+    TRY = 949,
+
+    /// <summary>
+    /// CFA Franc BEAC
+    /// XAF is used in Central African Republic, Cameroon, Chad, Republic of the Congo, Equatorial Guinea, Gabon
+    /// </summary>
+    XAF = 950,
+
+    /// <summary>
+    /// East Caribbean Dollar
+    /// XCD is used in Antigua and Barbuda, Dominica, Grenada, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines, Anguilla, Montserrat, Saint Kitts and Nevis, Saint Lucia
+    /// </summary>
+    XCD = 951,
+
+    /// <summary>
+    /// West African CFA franc
+    /// XOF is used in Benin, Burkina Faso, Ivory Coast, Guinea-Bissau, Mali, Niger, Senegal, Togo
+    /// </summary>
+    XOF = 952,
+
+    /// <summary>
+    /// CFP Franc
+    /// XPF is used in French Polynesia, New Caledonia, Wallis and Futuna
+    /// </summary>
+    XPF = 953,
+
+    /// <summary>
+    /// Zambian Kwacha
+    /// ZMW is used in Zambia
+    /// </summary>
+    ZMW = 967,
+
+    /// <summary>
+    /// Surinamese Dollar
+    /// SRD is used in Suriname
+    /// </summary>
+    SRD = 968,
+
+    /// <summary>
+    /// Malagasy Ariary
+    /// MGA is used in Madagascar
+    /// </summary>
+    MGA = 969,
+
+    /// <summary>
+    /// Unidad de Valor Real
+    /// COU is used in Colombia
+    /// </summary>
+    COU = 970,
+
+    /// <summary>
+    /// Afghan Afghani
+    /// AFN is used in Afghanistan
+    /// </summary>
+    AFN = 971,
+
+    /// <summary>
+    /// Tajikistani Somoni
+    /// TJS is used in Tajikistan
+    /// </summary>
+    TJS = 972,
+
+    /// <summary>
+    /// Angolan Kwanza
+    /// AOA is used in Angola
+    /// </summary>
+    AOA = 973,
+
+    /// <summary>
+    /// Bulgarian Lev
+    /// BGN is used in Bulgaria
+    /// </summary>
+    BGN = 975,
+
+    /// <summary>
+    /// Congolese Franc
+    /// CDF is used in the Democratic Republic of the Congo
+    /// </summary>
+    CDF = 976,
+
+    /// <summary>
+    /// Bosnia and Herzegovina Convertible Mark
+    /// BAM is used in Bosnia and Herzegovina
+    /// </summary>
+    BAM = 977,
+
+    /// <summary>
+    /// Euro
+    /// EUR is used in the Eurozone, Andorra, Kosovo, Monaco, Montenegro, San Marino, Vatican City
+    /// </summary>
+    EUR = 978,
+
+    /// <summary>
+    /// Ukrainian Hryvnia
+    /// UAH is used in Ukraine
+    /// </summary>
+    UAH = 980,
+
+    /// <summary>
+    /// Georgian Lari
+    /// GEL is used in Georgia
+    /// </summary>
+    GEL = 981,
+
+    /// <summary>
+    /// Bolivian Boliviano
+    /// BOV is used in Bolivia
+    /// </summary>
+    BOV = 984,
+
+    /// <summary>
+    /// Polish Złoty
+    /// PLN is used in Poland
+    /// </summary>
+    PLN = 985,
+
+    /// <summary>
+    /// Brazilian Real
+    /// BRL is used in Brazil
+    /// </summary>
+    BRL = 986,
+
+    /// <summary>
+    /// Chilean Unit of Account (UF)
+    /// CLF is used in Chile
+    /// </summary>
+    CLF = 990,
+
+    /// <summary>
+    /// Sucre
+    /// XSU is used in Ecuador
+    /// </summary>
+    XSU = 994,
+}

--- a/src/Portalum.Zvt/Portalum.Zvt.csproj
+++ b/src/Portalum.Zvt/Portalum.Zvt.csproj
@@ -19,7 +19,7 @@
 
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6</TargetFrameworks>
 
-    <Version>3.3.1</Version>
+    <Version>3.3.1-currency</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Portalum.Zvt/RegistrationConfig.cs
+++ b/src/Portalum.Zvt/RegistrationConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Portalum.Zvt.Helpers;
+using Portalum.Zvt.Models;
 
 namespace Portalum.Zvt
 {
@@ -63,6 +64,11 @@ namespace Portalum.Zvt
         public bool ActivateTlvSupport = true;
 
         #endregion
+
+        /// <summary>
+        /// ISO 4217 Currency Code
+        /// </summary>
+        public CurrencyCodeIso4217 CurrencyCode = CurrencyCodeIso4217.EUR;
 
         /// <summary>
         /// Get config byte

--- a/src/Portalum.Zvt/ZvtClient.cs
+++ b/src/Portalum.Zvt/ZvtClient.cs
@@ -415,7 +415,7 @@ namespace Portalum.Zvt
 
             //Currency Code (CC)
             //ISO4217 (https://en.wikipedia.org/wiki/ISO_4217)
-            var currencyNumericCodeData = NumberHelper.IntToBcd(978, 2); //978 = Euro
+            var currencyNumericCodeData = NumberHelper.IntToBcd((int)registrationConfig.CurrencyCode, 2);
             package.AddRange(currencyNumericCodeData);
 
             //Service byte
@@ -465,10 +465,12 @@ namespace Portalum.Zvt
         /// </summary>
         /// <param name="amount"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="currency"></param>
         /// <returns></returns>
         public async Task<CommandResponse> PaymentAsync(
             decimal amount,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            CurrencyCodeIso4217? currency = null)
         {
             this._logger.LogInformation($"{nameof(PaymentAsync)} - Execute with amount of:{amount}");
 
@@ -477,6 +479,11 @@ namespace Portalum.Zvt
             package.Add(0x04); //Amount prefix
             package.AddRange(NumberHelper.DecimalToBcd(amount));
 
+            if (currency != null)
+            {
+                package.Add(0x49); //currency prefix
+                package.AddRange(NumberHelper.IntToBcd((int)currency, 2));
+            }
             if (this.CompletionDecisionRequested != null)
             {
                 package.Add(0x02); // max nr. of status-informations
@@ -517,10 +524,12 @@ namespace Portalum.Zvt
         /// </summary>
         /// <param name="amount"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="currency"></param>
         /// <returns></returns>
         public async Task<CommandResponse> RefundAsync(
             decimal amount,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            CurrencyCodeIso4217? currency = null)
         {
             this._logger.LogInformation($"{nameof(RefundAsync)} - Execute");
 
@@ -528,6 +537,11 @@ namespace Portalum.Zvt
             package.AddRange(this._passwordData);
             package.Add(0x04); //Amount prefix
             package.AddRange(NumberHelper.DecimalToBcd(amount));
+            if (currency != null)
+            {
+                package.Add(0x49); //currency prefix
+                package.AddRange(NumberHelper.IntToBcd((int)currency, 2));
+            }
 
             var fullPackage = PackageHelper.Create(new byte[] { 0x06, 0x31 }, package);
             return await this.SendCommandAsync(fullPackage, cancellationToken: cancellationToken);


### PR DESCRIPTION
Add ISO 4217 currency code enumeration with 996 currency definitions. Replaces hardcoded EUR with configurable currency via `RegistrationConfig.CurrencyCode`. `PaymentAsync()` and `RefundAsync()` now accept optional currency override parameter. Fully backward compatible—existing code continues to work unchanged.


